### PR TITLE
Add Summaries.md with summaries of URLs from Links.md

### DIFF
--- a/Summaries.md
+++ b/Summaries.md
@@ -1,0 +1,301 @@
+# URL Summaries
+
+### [https://www.chir.app/codex.html](https://www.chir.app/codex.html)
+
+**Summary:** 🌐 The Geodetic Codex & ChiR Labs   Where Ancient Wisdom Meets Modern Geodesy & HPC                🔭 Codex Portal: current research papers 🌍   [1]Harmonic Intelligence & The Geodetic Codex: Planetary-Scale Res
+
+---
+
+### [https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=1644](https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=1644)
+
+**Summary:** [1]Skip to main content [2]ORNL DAAC Home[3]NASA Home * [4]Home * [5]About Us + [6]Mission + [7]Data Use and Citation Guidelines + [8]User Working Group + [9]Partners * [10]Get Data + [11]Science Them
+
+---
+
+### [https://news.mongabay.com/2019/11/lidar-technology-leads-brazilian-team-to-30-story-tall-amazon-tree/](https://news.mongabay.com/2019/11/lidar-technology-leads-brazilian-team-to-30-story-tall-amazon-tree/)
+
+**Summary:** #[1]JSON [2]oEmbed (JSON) [3]oEmbed (XML) [4]publisher Clicky [5][mongabay_logo_news_black.svg] [6][mongabay_logo_news_white.svg] * [7]Features * [8]Videos * [9]Podcasts * [10]Specials * [11]Artic
+
+---
+
+### [https://www.science.org/content/article/laser-mapping-reveals-hidden-structures-in-amazon-hints-thousands-more](https://www.science.org/content/article/laser-mapping-reveals-hidden-structures-in-amazon-hints-thousands-more)
+
+**Summary:** Failed to fetch content: Disallowed by robots.txt
+
+---
+
+### [https://bjornoste.com/arkhub](https://bjornoste.com/arkhub)
+
+**Summary:** [1] My work [2] Biography [3] Philanthropy [4] Blog [5] My work [6] Biography [7] Philanthropy [8] Blog [9] My work [10] Biography [11] Philanthropy [12] Blog Arkhub Arkhub Arkhub Nexus for Arc
+
+---
+
+### [https://www.kaggle.com/competitions/openai-to-z-challenge/overview/submission-instructions](https://www.kaggle.com/competitions/openai-to-z-challenge/overview/submission-instructions)
+
+**Summary:** Failed to fetch content: Empty response
+
+---
+
+### [https://journal.caa-international.org/articles/10.5334/jcaa.45](https://journal.caa-international.org/articles/10.5334/jcaa.45)
+
+**Summary:** Failed to fetch content: Disallowed by robots.txt
+
+---
+
+### [https://www.science.org/doi/10.1126/science.ade2541](https://www.science.org/doi/10.1126/science.ade2541)
+
+**Summary:** Failed to fetch content: Disallowed by robots.txt
+
+---
+
+### [https://pubmed.ncbi.nlm.nih.gov/29588444/](https://pubmed.ncbi.nlm.nih.gov/29588444/)
+
+**Summary:** #[1]PubMed search This site needs JavaScript to work properly. Please enable it to take advantage of the complete set of features! Clipboard, Search History, and several other advanced features ar
+
+---
+
+### [https://pmc.ncbi.nlm.nih.gov/articles/PMC10069417/](https://pmc.ncbi.nlm.nih.gov/articles/PMC10069417/)
+
+**Summary:** [1]Skip to main content An official website of the United States government Here's how you know (BUTTON) Here's how you know Official websites use .gov A .gov website belongs to an official governmen
+
+---
+
+### [https://www.sciencedirect.com/science/article/pii/S0016706116302725#:~:text=Sensor%20mapping%20of%20Amazonian%20Dark,terra%20preta%20de%20%C3%8Dndio](https://www.sciencedirect.com/science/article/pii/S0016706116302725#:~:text=Sensor%20mapping%20of%20Amazonian%20Dark,terra%20preta%20de%20%C3%8Dndio)
+
+**Summary:** JavaScript is disabled on your browser. Please enable JavaScript to use all the features on this page. [1748234844690?pageName=sd%3Aproduct%3Ajournal%3Aarticle&c16=els%3Arp%3 Ast&c2=sd&v185=img&v33=ae%3AANON_GUES
+
+---
+
+### [https://www.science.org/doi/10.1126/science.ade2541](https://www.science.org/doi/10.1126/science.ade2541)
+
+**Summary:** Failed to fetch content: Disallowed by robots.txt
+
+---
+
+### [https://www.kaggle.com/competitions/openai-to-z-challenge/discussion/578996](https://www.kaggle.com/competitions/openai-to-z-challenge/discussion/578996)
+
+**Summary:** Failed to fetch content: Empty response
+
+---
+
+### [https://cdn.openai.com/pdf/a9455c3b-c6e1-49cf-a5cc-c40ed07c0b9f/starter-pack-openai-to-z-challenge.pdf](https://cdn.openai.com/pdf/a9455c3b-c6e1-49cf-a5cc-c40ed07c0b9f/starter-pack-openai-to-z-challenge.pdf)
+
+**Summary:** %PDF-1.4 %???? 1 0 obj <</Title (Starter Pack: OpenAI to Z Challenge) /Producer (Skia/PDF m138 Google Docs Renderer)>> endobj 3 0 obj <</ca 1 /BM /Normal>> endobj 14 0 obj <</CA 1 /ca 1 /LC 0 /LJ 0 /LW 1.
+
+---
+
+### [https://www.youtube.com/watch?v=PverKqpijCY](https://www.youtube.com/watch?v=PverKqpijCY)
+
+**Summary:** #[1]YouTube [2]alternate [3]alternate [4]alternate [5]alternate IFRAME: [6]passive_signin ____________________ [7]About[8]Press[9]Copyright[10]Contact us[11]Creators[12]Advertise[13]Developers[14]Te
+
+---
+
+### [https://www.science.org/doi/10.1126/science.ade2541](https://www.science.org/doi/10.1126/science.ade2541)
+
+**Summary:** Failed to fetch content: Disallowed by robots.txt
+
+---
+
+### [https://youtu.be/hv5FCeX_UZA?si=QpPbjds7DXhEi3ey](https://youtu.be/hv5FCeX_UZA?si=QpPbjds7DXhEi3ey)
+
+**Summary:** #[1]YouTube [2]alternate [3]alternate [4]alternate [5]alternate [6]Arc Neo hypothesis [7]Arc Neo hypothesis IFRAME: [8]passive_signin ____________________ [9]About[10]Press[11]Copyright[12]Contact 
+
+---
+
+### [https://www.kaggle.com/datasets/beastgokul/forested-areas-para-brazil-1514](https://www.kaggle.com/datasets/beastgokul/forested-areas-para-brazil-1514)
+
+**Summary:** Failed to fetch content: Empty response
+
+---
+
+### [https://www.kaggle.com/code/wguesdon/how-to-experiment-with-free-models](https://www.kaggle.com/code/wguesdon/how-to-experiment-with-free-models)
+
+**Summary:** #[1]How to Experiment with Free Models
+
+---
+
+### [https://www.kaggle.com/code/wguesdon/creating-a-knowledge-base-for-rag-llm](https://www.kaggle.com/code/wguesdon/creating-a-knowledge-base-for-rag-llm)
+
+**Summary:** #[1]Creating a Knowledge Base - paid models
+
+---
+
+### [https://www.kaggle.com/code/wguesdon/rag-llm-openai-vector-stores](https://www.kaggle.com/code/wguesdon/rag-llm-openai-vector-stores)
+
+**Summary:** #[1]RAG - LLM - OpenAI Vector Stores
+
+---
+
+### [https://www.kaggle.com/code/aaronbornstein/extracting-known-archeology-sites-from-wiki](https://www.kaggle.com/code/aaronbornstein/extracting-known-archeology-sites-from-wiki)
+
+**Summary:** #[1]🌐 Extracting Known Archeology Sites from Wiki
+
+---
+
+### [https://www.kaggle.com/code/antonsibilev/amazon-data-bridge-v1](https://www.kaggle.com/code/antonsibilev/amazon-data-bridge-v1)
+
+**Summary:** #[1]Amazon Data Bridge v1
+
+---
+
+### [https://daac.ornl.gov/CMS/guides/LiDAR_Forest_Inventory_Brazil.html](https://daac.ornl.gov/CMS/guides/LiDAR_Forest_Inventory_Brazil.html)
+
+**Summary:** [1]Skip to main content [2]ORNL DAAC Home[3]NASA Home * [4]Home * [5]About Us + [6]Mission + [7]Data Use and Citation Guidelines + [8]User Working Group + [9]Partners * [10]Get Data + [11]Science The
+
+---
+
+### [https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=1515](https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=1515)
+
+**Summary:** [1]Skip to main content [2]ORNL DAAC Home[3]NASA Home * [4]Home * [5]About Us + [6]Mission + [7]Data Use and Citation Guidelines + [8]User Working Group + [9]Partners * [10]Get Data + [11]Science Them
+
+---
+
+### [https://daac.ornl.gov/VEGETATION/guides/Forested_Areas_Amazonas_Brazil.html](https://daac.ornl.gov/VEGETATION/guides/Forested_Areas_Amazonas_Brazil.html)
+
+**Summary:** [1]Skip to main content [2]ORNL DAAC Home[3]NASA Home * [4]Home * [5]About Us + [6]Mission + [7]Data Use and Citation Guidelines + [8]User Working Group + [9]Partners * [10]Get Data + [11]Science The
+
+---
+
+### [https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=1302](https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=1302)
+
+**Summary:** [1]Skip to main content [2]ORNL DAAC Home[3]NASA Home * [4]Home * [5]About Us + [6]Mission + [7]Data Use and Citation Guidelines + [8]User Working Group + [9]Partners * [10]Get Data + [11]Science Them
+
+---
+
+### [https://zenodo.org/records/7689909](https://zenodo.org/records/7689909)
+
+**Summary:** #[1]alternate [2]alternate [3]Skip to main [4]Zenodo home (BUTTON) (BUTTON) ____________________ [5]Communities [6]My dashboard [7]Log in [8]Sign up [9]Remote sensing Published March 1, 2023 | Vers
+
+---
+
+### [https://www.paisagenslidar.cnptia.embrapa.br/](https://www.paisagenslidar.cnptia.embrapa.br/)
+
+**Summary:** Failed to fetch content: Disallowed by robots.txt
+
+---
+
+### [https://zenodo.org/records/7104044](https://zenodo.org/records/7104044)
+
+**Summary:** #[1]alternate [2]alternate [3]alternate [4]alternate [5]alternate [6]alternate [7]alternate [8]alternate [9]Skip to main [10]Zenodo home (BUTTON) (BUTTON) ____________________ [11]Communities [12]My da
+
+---
+
+### [https://www.ccst.inpe.br/projetos/eba-estimativa-de-biomassa-na-amazonia/](https://www.ccst.inpe.br/projetos/eba-estimativa-de-biomassa-na-amazonia/)
+
+**Summary:** #[1]oEmbed (JSON) [2]oEmbed (XML) IFRAME: [3]https://www.googletagmanager.com/ns.html?id=GTM-5V3SDH3 [4]Ir direto para menu de acessibilidade. Seu navegador de internet está sem suporte à JavaScri
+
+---
+
+### [https://portal.opentopography.org/datasetMetadata?otCollectionID=OT.042013.4326.1](https://portal.opentopography.org/datasetMetadata?otCollectionID=OT.042013.4326.1)
+
+**Summary:** [1]Skip to main content * [2]Getting Started * [3]MyOpenTopo * [4]Premium Subscriptions Search form Search OpenTopo Submit [5]Home [6]OpenTopography High-Resolution Topography Data and Tools * [7]Home
+
+---
+
+### [https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=1514](https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=1514)
+
+**Summary:** [1]Skip to main content [2]ORNL DAAC Home[3]NASA Home * [4]Home * [5]About Us + [6]Mission + [7]Data Use and Citation Guidelines + [8]User Working Group + [9]Partners * [10]Get Data + [11]Science Them
+
+---
+
+### [https://daac.ornl.gov/VEGETATION/guides/Forested_Areas_Para_Brazil](https://daac.ornl.gov/VEGETATION/guides/Forested_Areas_Para_Brazil)
+
+**Summary:** [1]Skip to main content [2]ORNL DAAC Home[3]NASA Home * [4]Home * [5]About Us + [6]Mission + [7]Data Use and Citation Guidelines + [8]User Working Group + [9]Partners * [10]Get Data + [11]Science The
+
+---
+
+### [https://journal.caa-international.org/articles/10.5334/jcaa.45](https://journal.caa-international.org/articles/10.5334/jcaa.45)
+
+**Summary:** Failed to fetch content: Disallowed by robots.txt
+
+---
+
+### [https://www.science.org/doi/10.1126/science.ade2541](https://www.science.org/doi/10.1126/science.ade2541)
+
+**Summary:** Failed to fetch content: Disallowed by robots.txt
+
+---
+
+### [https://pubmed.ncbi.nlm.nih.gov/29588444/](https://pubmed.ncbi.nlm.nih.gov/29588444/)
+
+**Summary:** #[1]PubMed search This site needs JavaScript to work properly. Please enable it to take advantage of the complete set of features! Clipboard, Search History, and several other advanced features ar
+
+---
+
+### [https://pmc.ncbi.nlm.nih.gov/articles/PMC10069417/](https://pmc.ncbi.nlm.nih.gov/articles/PMC10069417/)
+
+**Summary:** [1]Skip to main content An official website of the United States government Here's how you know (BUTTON) Here's how you know Official websites use .gov A .gov website belongs to an official governmen
+
+---
+
+### [https://sites.google.com/view/amazonarch](https://sites.google.com/view/amazonarch)
+
+**Summary:** ____________________ Search this site Embedded Files (BUTTON) Skip to main content (BUTTON) Skip to navigation [1]AmazonArch * [2]Home * [3]Publications * [4]Data sharing and use policy * [5]About us 
+
+---
+
+### [https://WeatherAPI.com](https://WeatherAPI.com)
+
+**Summary:** Failed to fetch content: Failed to fetch robots.txt
+
+---
+
+### [https://cordis.europa.eu/](https://cordis.europa.eu/)
+
+**Summary:** #[1]alternate [2]alternate [3]alternate [4]alternate [5]alternate [6]alternate [7]Skip to main content (BUTTON) Log out Logging out of EU Login will log you out of any other services that use your EU 
+
+---
+
+### [https://whc.unesco.org/](https://whc.unesco.org/)
+
+**Summary:** #[1]RSS News [2]RSS Events [3]RSS Sites [4]WHC [5]alternate [6]alternate [7]alternate IFRAME: [8]https://www.googletagmanager.com/ns.html?id=GTM-T9NW Your browser does not support JavaScript. [9]UNE
+
+---
+
+### [https://sarahklassen.ca/](https://sarahklassen.ca/)
+
+**Summary:** [1]0 [2]Skip to Content [3]sarahklassen.ca [4]Research Interests [5]Research Projects [6]Dissertation [7]Cultural Resource Management (BUTTON) Open Menu Close Menu [8]sarahklassen.ca [9]Research Inter
+
+---
+
+### [https://youtu.be/hv5FCeX_UZA?si=QpPbjds7DXhEi3ey](https://youtu.be/hv5FCeX_UZA?si=QpPbjds7DXhEi3ey)
+
+**Summary:** #[1]YouTube [2]alternate [3]alternate [4]alternate [5]alternate [6]Arc Neo hypothesis [7]Arc Neo hypothesis IFRAME: [8]passive_signin ____________________ [9]About[10]Press[11]Copyright[12]Contact 
+
+---
+
+### [https://zenodo.org/records/15270341](https://zenodo.org/records/15270341)
+
+**Summary:** #[1]alternate [2]alternate [3]alternate [4]alternate [5]alternate [6]alternate [7]alternate [8]alternate [9]alternate [10]alternate [11]alternate [12]alternate [13]alternate [14]alternate [15]altern
+
+---
+
+### [https://www.nature.com/articles/s41597-021-01067-7](https://www.nature.com/articles/s41597-021-01067-7)
+
+**Summary:** Failed to fetch content: Disallowed by robots.txt
+
+---
+
+### [https://plas.io/](https://plas.io/)
+
+**Summary:** plas.io Sorry, your browser does not support WebGL. [1]Find out more. Drop Here! plas.io [2]Fork me on GitHub File Choose data to display Pick your own or click the dropdown for some examples (BUTTON)
+
+---
+
+### [https://www.kaggle.com/code/aaronbornstein/extracting-known-archeology-sites-from-wiki](https://www.kaggle.com/code/aaronbornstein/extracting-known-archeology-sites-from-wiki)
+
+**Summary:** #[1]🌐 Extracting Known Archeology Sites from Wiki
+
+---
+
+### [https://etsin.fairdata.fi/dataset/54f01053-3ea7-4679-a36b-f7146911c345/data](https://etsin.fairdata.fi/dataset/54f01053-3ea7-4679-a36b-f7146911c345/data)
+
+**Summary:** Javascript needs to be enabled to see this page
+
+---
+
+### [https://www.kaggle.com/code/fafa92/i-follow-rivers](https://www.kaggle.com/code/fafa92/i-follow-rivers)
+
+**Summary:** #[1]I Follow Rivers
+
+---


### PR DESCRIPTION
This commit introduces a new file, Summaries.md, which contains summaries of web content from URLs found in Links.md. Each URL's content was fetched, and a brief summary was generated. If a URL could not be fetched or summarized, a note indicating the reason (e.g., robots.txt disallowal, empty response) is included.